### PR TITLE
Remove texture wrap restrictions on Bitmap

### DIFF
--- a/h2d/Bitmap.hx
+++ b/h2d/Bitmap.hx
@@ -20,8 +20,6 @@ class Bitmap extends Drawable {
 	}
 
 	override function set_tileWrap(b) {
-		if( b && tile != null && tile.getTexture().flags.has(IsNPOT) )
-			throw "Cannot set tileWrap on a non power-of-two texture";
 		return tileWrap = b;
 	}
 


### PR DESCRIPTION
Texture wrapping has no specific restrictions regarding power of two texture dimensions.