### PR TITLE
Reduce unwanted allocations on various places

### DIFF
--- a/h2d/col/Ray.hx
+++ b/h2d/col/Ray.hx
@@ -23,6 +23,9 @@ class Ray {
 		return dx * (p.y - y) - dy * (p.x - x);
 	}
 
+	public inline function sideValue(valX:Float, valY:Float) {
+		return dx * (valY - y) - dy * (valX - x);
+	}
 
 	public inline function getPos() {
 		return new Point(x, y);

--- a/h2d/col/Segment.hx
+++ b/h2d/col/Segment.hx
@@ -64,7 +64,7 @@ class Segment {
 	}
 
 	public inline function lineIntersection( r : h2d.col.Ray, ?pt : Point ) {
-		if( r.side(new Point(x, y)) * r.side(new Point(x + dx, y + dy)) > 0 )
+		if( r.sideValue(x, y) * r.sideValue(x + dx, y + dy) > 0 )
 			return null;
 
 		var u = ( r.dx * (y - r.y) - r.dy * (x - r.x) ) / ( r.dy * dx - r.dx * dy );

--- a/h3d/impl/GlDriver.hx
+++ b/h3d/impl/GlDriver.hx
@@ -181,7 +181,7 @@ class GlDriver extends Driver {
 	var debug : Bool;
 	var glDebug : Bool;
 	var boundTextures : Array<Texture> = [];
-	var glES : Null<Float>;
+	var glES : Float = -1.0;
 	var shaderVersion : Null<Int>;
 	var firstShader = true;
 	var rightHanded = false;
@@ -220,7 +220,7 @@ class GlDriver extends Driver {
 			glES = Std.parseFloat(reg.matched(1));
 
 		#if !js
-		if( glES == null ) {
+		if( glES < 0.0 ) {
 			commonVA = gl.createVertexArray();
 			gl.bindVertexArray( commonVA );
 		}
@@ -375,7 +375,7 @@ class GlDriver extends Driver {
 
 			p.p = gl.createProgram();
 			#if ((hlsdl || usegl) && !hlmesa)
-			if( glES == null ) {
+			if( glES < 0.0 ) {
 				var outCount = 0;
 				for( v in shader.fragment.data.vars )
 					switch( v.kind ) {


### PR DESCRIPTION
* Add a new method for line intersection test with only coordinate parameter
Segment was allocating new Point for line intersection test only for checking on which side is the specified coordinate from the ray.

* Remove nullable encapsulation for OpenGL version parsing