### PR TITLE
Add pak stamping to avoid loading unwanted data

### DIFF
--- a/hxd/fmt/pak/Build.hx
+++ b/hxd/fmt/pak/Build.hx
@@ -166,7 +166,7 @@ class Build {
 		return out;
 	}
 
-	function makePak() {
+	function makePak(pakStampHash:String = null) {
 
 		if( !sys.FileSystem.exists(resPath) )
 			throw "'" + resPath + "' resource directory was not found";
@@ -190,7 +190,8 @@ class Build {
 
 		var pak = new Data();
 		out = { bytes : [], size : 0 };
-		pak.version = 0;
+		pak.version = 1;
+		pak.stampHash = pakStampHash;
 		pak.root = buildRec("");
 
 		if( pakDiff ) {

--- a/hxd/fmt/pak/Data.hx
+++ b/hxd/fmt/pak/Data.hx
@@ -7,8 +7,7 @@ class File {
 	public var dataPosition : Int;
 	public var dataSize : Int;
 	public var checksum : Int;
-	public function new() {
-	}
+	public function new() {}
 }
 
 class Data {
@@ -16,6 +15,6 @@ class Data {
 	public var root : File;
 	public var headerSize : Int;
 	public var dataSize : Int;
-	public function new() {
-	}
+	public var stampHash : String;
+	public function new() {}
 }

--- a/hxd/fmt/pak/FileSystem.hx
+++ b/hxd/fmt/pak/FileSystem.hx
@@ -166,6 +166,7 @@ class PakEntry extends FileEntry {
 }
 
 class FileSystem implements hxd.fs.FileSystem {
+	public static var PAK_STAMP_HASH : String;
 
 	var root : PakEntry;
 	var dict : Map<String,PakEntry>;
@@ -186,7 +187,7 @@ class FileSystem implements hxd.fs.FileSystem {
 		root = new PakEntry(this, null, f, null);
 	}
 
-	public function loadPak( file : String ) {
+	public function loadPak(file : String) {
 		#if (air3 || sys)
 		addPak(File.read(file));
 		#else
@@ -239,8 +240,14 @@ class FileSystem implements hxd.fs.FileSystem {
 		#end
 	}
 
-	public function addPak( s : FileInput, modPak : Bool = false ) {
+	public function addPak(s : FileInput, modPak : Bool = false) {
 		var pak = new Reader(s).readHeader();
+
+		// Filter unsigned pak from game data
+		if(!modPak && pak.stampHash != PAK_STAMP_HASH) {
+			return;
+		}
+
 		if( pak.root.isDirectory ) {
 			for( f in pak.root.content )
 				addRec(root, f.name, f, s, pak.headerSize, modPak);
@@ -363,5 +370,4 @@ class FileSystem implements hxd.fs.FileSystem {
 	public function dir( path : String ) : Array<FileEntry> {
 		throw "Not Supported";
 	}
-
 }

--- a/hxd/fmt/pak/Reader.hx
+++ b/hxd/fmt/pak/Reader.hx
@@ -15,9 +15,18 @@ class Reader {
 		pak.version = i.readByte();
 		pak.headerSize = i.readInt32();
 		pak.dataSize = i.readInt32();
+
+		var headerLength:Int = pak.headerSize - 16;
+
+		if(pak.version >= 1) {
+			pak.stampHash = i.readString(64);
+			headerLength -= 64;
+		}
+
 		// single read header
 		var old = i;
-		i = new haxe.io.BytesInput(i.read(pak.headerSize - 16));
+
+		i = new haxe.io.BytesInput(i.read(headerLength));
 		pak.root = readFile();
 		i = old;
 		if( i.readString(4) != "DATA" ) throw "Corrupted PAK header";

--- a/hxd/fmt/pak/Writer.hx
+++ b/hxd/fmt/pak/Writer.hx
@@ -15,6 +15,7 @@ class Writer {
 		var flags = 0;
 		if( f.isDirectory ) flags |= 1;
 		o.writeByte(flags);
+
 		if( f.isDirectory ) {
 			o.writeInt32(f.content.length);
 			for( f in f.content )
@@ -27,30 +28,41 @@ class Writer {
 	}
 
 	public function write( pak : Data, content : haxe.io.Bytes, ?arrayContent : Array<haxe.io.Bytes> ) {
-
 		if( arrayContent != null ) {
 			pak.dataSize = 0;
 			for( b in arrayContent )
 				pak.dataSize += b.length;
-		} else
+		} else {
 			pak.dataSize = content.length;
+		}
 
-		var header = new haxe.io.BytesOutput();
-		new Writer(header).writeFile(pak.root);
-		var header = header.getBytes();
+		var headerOutput = new haxe.io.BytesOutput();
+		new Writer(headerOutput).writeFile(pak.root);
+		var header = headerOutput.getBytes();
 		pak.headerSize = header.length + 16;
+
+		if(pak.version >= 1) {
+			pak.headerSize += 64;
+		}
 
 		o.writeString("PAK");
 		o.writeByte(pak.version);
 		o.writeInt32(pak.headerSize);
 		o.writeInt32(pak.dataSize);
+
+		if(pak.version >= 1) {
+			o.writeString(pak.stampHash);
+		}
+
 		o.write(header);
 		o.writeString("DATA");
+
 		if( arrayContent != null ) {
 			for( b in arrayContent )
 				o.write(b);
-		} else
+		} else {
 			o.write(content);
+		}
 	}
 
 }


### PR DESCRIPTION
Method `addPak` will know check if the pak stamping is coherent with the one provided with the game.